### PR TITLE
remove seo exception handler

### DIFF
--- a/cakephp/templates/default/core.php.erb
+++ b/cakephp/templates/default/core.php.erb
@@ -77,13 +77,6 @@ Configure::write('Exception', array(
 'renderer' => 'ExceptionRenderer',
 'log' => true
 ));
-if (class_exists('SeoExceptionHandler')) {
-  Configure::write('Exception', array(
-  'handler' => 'SeoExceptionHandler::handle',
-  'renderer' => 'ExceptionRenderer',
-  'log' => true
-  ));
-}
 
 /**
 * Application wide charset encoding


### PR DESCRIPTION
BTCOM-1006 #fixed

Test Plan:

Should fix the error we're getting on stage about the SEO exception handler. We don't use it anymore so we might as well remove it.